### PR TITLE
Updating Link Error in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tranco
 
-This package allows easy access to the Tranco list, published at [https://tranco-list.eu]().
+This package allows easy access to the Tranco list, published at [https://tranco-list.eu](https://tranco-list.eu/).
 
 ## Usage
 


### PR DESCRIPTION
The Readme link currently directs to https://github.com/DistriNet/tranco-python-package/blob/master since the link field is empty. This results in a 404 error.

I find the Tranco list really useful, thank you, and am using it for research purposes myself hence why I've made this very small change to help out.