### PR TITLE
Store the list as a dictionary for faster rank lookups

### DIFF
--- a/tranco/tranco.py
+++ b/tranco/tranco.py
@@ -11,10 +11,10 @@ class TrancoList():
         self.date = date
         self.list_id = list_id
         self.list_page = "https://tranco-list.eu/list/{}/1000000".format(list_id)
-        self.list = {domain: index + 1 for index, domain in enumerate(lst)}
+        self.list = {domain: index for index, domain in enumerate(lst, start=1)}
 
     def top(self, num=1000000):
-        return [domain for domain in sorted(self.list, key=self.list.get)][:num]
+        return sorted(self.list, key=self.list.get)[:num]
 
     def rank(self, domain):
         return self.list.get(domain, -1)

--- a/tranco/tranco.py
+++ b/tranco/tranco.py
@@ -11,16 +11,13 @@ class TrancoList():
         self.date = date
         self.list_id = list_id
         self.list_page = "https://tranco-list.eu/list/{}/1000000".format(list_id)
-        self.list = lst
+        self.list = {domain: index + 1 for index, domain in enumerate(lst)}
 
     def top(self, num=1000000):
-        return self.list[:num]
+        return [domain for domain in sorted(self.list, key=self.list.get)][:num]
 
     def rank(self, domain):
-        try:
-            return self.list.index(domain) + 1
-        except ValueError:
-            return -1
+        return self.list.get(domain, -1)
 
 class Tranco():
     def __init__(self, **kwargs):


### PR DESCRIPTION
This PR fixes issue #7 by storing the list of domains as a dictionary instead of a list, which makes looking up items via the `rank` function considerably quicker.